### PR TITLE
Fixed - Alerta de tempo restante (5 min) repetitivo

### DIFF
--- a/script.js
+++ b/script.js
@@ -145,8 +145,9 @@ document.addEventListener('DOMContentLoaded', function() {
             timerDisplay.textContent = formatTime(hours, minutes, seconds);
             
             // Alerta quando restam 5 minutos
-            if (remainingTime <= 5 * 60 * 1000 && remainingTime > 4 * 60 * 1000) {
-                showNotification('Atenção: Restam apenas 5 minutos!', 'error');
+            const alertTimeMinutes = 5; //Tempo restante, em  minutos, para mostrar o alerta
+            if (remainingTime <= alertTimeMinutes * 60 * 1000 && remainingTime > (alertTimeMinutes * 60 * 1000) - 1000) {
+                showNotification('Atenção: Restam apenas ' + alertTimeMinutes + ' minutos!', 'error');
                 timerDisplay.style.color = 'var(--danger-color)';
             }
             


### PR DESCRIPTION
Closes #1

Foi feita uma pequena alteração para a mensagem de alerta que avisa sobre os 5 minutos restantes de prova ser exibida apenas uma vez quando o tempo diminui de 5 minutos, não se repetindo repetindo e se sobrepondo em um intervalo de 1 minuto entre 5:00 e 4:00.

Além disso, a informação de 5 minutos foi transformada em constante para facilitar futuras cópias ou modificações no trecho do código.